### PR TITLE
162366202 crUd job experiences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem "chromedriver-helper"
   gem "factory_bot_rails", "~> 4.0"
+  gem "faker"
   gem "rack_session_access"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faker (1.9.1)
+      i18n (>= 0.7)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -266,6 +268,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   factory_bot_rails (~> 4.0)
+  faker
   jbuilder (~> 2.5)
   launchy
   letter_opener

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,12 +6,12 @@
   border-radius: 0px;
   margin-top: 0px;
 
-  .item {
+  a.item, div.dropdown.item {
     color: $white;
 
     &:hover {
-      background: rgba(0,0,0,.03);
-      color: rgba(0,0,0,.95);
+      background-color: $primary-dark;
+      color: $white;
     }
   }
 
@@ -24,4 +24,18 @@
 
 .ui.floating.message {
   margin-bottom: 0px;
+}
+
+.ui.button {
+  background-color: $primary;
+  color: $white;
+
+  &:hover {
+    background-color: $primary-dark;
+    color: $white;
+  }
+
+  a {
+    color: $white;
+  }
 }

--- a/app/assets/stylesheets/job-experiences.scss
+++ b/app/assets/stylesheets/job-experiences.scss
@@ -16,6 +16,9 @@
       color: $text;
       white-space: pre-line;
     }
+    .label {
+      margin: 10px 0px;
+    }
   }
 
   .ui.label {

--- a/app/controllers/job_experiences_controller.rb
+++ b/app/controllers/job_experiences_controller.rb
@@ -8,6 +8,7 @@ class JobExperiencesController < ApplicationController
   def create
     @job_experience = authorize JobExperience.new job_experience_params
     if @job_experience.save
+      add_collaborator @job_experience
       flash.notice = "Your experience has been saved."
       redirect_to root_path
     else
@@ -23,6 +24,7 @@ class JobExperiencesController < ApplicationController
   def update
     @job_experience = authorize JobExperience.find params[:id]
     if @job_experience.update job_experience_params
+      add_collaborator @job_experience
       flash.notice = "This experience has been updated."
       redirect_to root_path
     else
@@ -44,5 +46,11 @@ class JobExperiencesController < ApplicationController
       :website,
       :creator_id
     )
+  end
+
+  def add_collaborator job_experience
+    unless job_experience.collaborator_user_ids.include? @current_user.id
+      Collaborator.create(user_id: @current_user.id, job_experience_id: job_experience.id)
+    end
   end
 end

--- a/app/controllers/job_experiences_controller.rb
+++ b/app/controllers/job_experiences_controller.rb
@@ -23,7 +23,7 @@ class JobExperiencesController < ApplicationController
   def update
     @job_experience = authorize JobExperience.find params[:id]
     if @job_experience.update job_experience_params
-      flash.notice = "Your experience has been updated."
+      flash.notice = "This experience has been updated."
       redirect_to root_path
     else
       render :edit

--- a/app/controllers/job_experiences_controller.rb
+++ b/app/controllers/job_experiences_controller.rb
@@ -6,13 +6,27 @@ class JobExperiencesController < ApplicationController
   end
 
   def create
-    @job_experience = JobExperience.new job_experience_params
+    @job_experience = authorize JobExperience.new job_experience_params
     if @job_experience.save
       flash.notice = "Your experience has been saved."
       redirect_to root_path
     else
       flash.alert = @job_experience.errors.full_messages.to_sentence
       render :new
+    end
+  end
+
+  def edit
+    @job_experience = authorize JobExperience.find params[:id]
+  end
+
+  def update
+    @job_experience = authorize JobExperience.find params[:id]
+    if @job_experience.update job_experience_params
+      flash.notice = "Your experience has been updated."
+      redirect_to root_path
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/job_experiences_controller.rb
+++ b/app/controllers/job_experiences_controller.rb
@@ -27,7 +27,8 @@ class JobExperiencesController < ApplicationController
       :experience,
       :pay,
       :recommendation,
-      :website
+      :website,
+      :creator_id
     )
   end
 end

--- a/app/models/collaborator.rb
+++ b/app/models/collaborator.rb
@@ -1,0 +1,4 @@
+class Collaborator < ApplicationRecord
+  belongs_to :user
+  belongs_to :job_experience
+end

--- a/app/models/job_experience.rb
+++ b/app/models/job_experience.rb
@@ -1,4 +1,7 @@
 class JobExperience < ApplicationRecord
+  has_many :users
+  belongs_to :creator, class_name: "User"
+  
   before_save :format_website
 
   def format_website

--- a/app/models/job_experience.rb
+++ b/app/models/job_experience.rb
@@ -1,7 +1,8 @@
 class JobExperience < ApplicationRecord
-  has_many :users
   belongs_to :creator, class_name: "User"
-  
+  has_many :collaborators
+  has_many :users, through: :collaborators
+
   before_save :format_website
 
   def format_website
@@ -11,5 +12,9 @@ class JobExperience < ApplicationRecord
         website = self.website.prepend('http://')
       end
     end
+  end
+
+  def collaborator_user_ids
+    self.collaborators.pluck(:user_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :job_experiences
+  
   validates_presence_of :first_name, :last_name
   validates :email, uniqueness: true, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  has_many :job_experiences
-  
+  has_many :collaborators
+  has_many :job_experiences, through: :collaborators
+
   validates_presence_of :first_name, :last_name
   validates :email, uniqueness: true, presence: true
 

--- a/app/policies/job_experience_policy.rb
+++ b/app/policies/job_experience_policy.rb
@@ -15,10 +15,10 @@ class JobExperiencePolicy < ApplicationPolicy
   end
 
   def edit?
-    @record.creator == @user
+    new?
   end
 
   def update?
-    edit?
+    new?
   end
 end

--- a/app/policies/job_experience_policy.rb
+++ b/app/policies/job_experience_policy.rb
@@ -9,4 +9,16 @@ class JobExperiencePolicy < ApplicationPolicy
   def new?
     user.present?
   end
+
+  def create?
+    new?
+  end
+
+  def edit?
+    @record.creator == @user
+  end
+
+  def update?
+    edit?
+  end
 end

--- a/app/views/job_experiences/edit.html.erb
+++ b/app/views/job_experiences/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="ui container">
   <div class="ui segment">
-    <h1 class="ui header">Update Your Job Experience</h1>
+    <h1 class="ui header">Edit This Job Experience</h1>
     <%= form_for @job_experience, html: {class: 'ui form'} do |f| %>
       <div class="field">
         <%= f.label :position %>

--- a/app/views/job_experiences/edit.html.erb
+++ b/app/views/job_experiences/edit.html.erb
@@ -1,0 +1,40 @@
+<div class="ui container">
+  <div class="ui segment">
+    <h1 class="ui header">Update Your Job Experience</h1>
+    <%= form_for @job_experience, html: {class: 'ui form'} do |f| %>
+      <div class="field">
+        <%= f.label :position %>
+        <%= f.text_field :position, placeholder: "Cashier" %>
+      </div>
+      <div class="field">
+        <%= f.label :company %>
+        <%= f.text_field :company, placeholder: "Walmart" %>
+      </div>
+      <div class="field">
+        <%= f.label :city %>
+        <%= f.text_field :city, placeholder: "Loveland" %>
+      </div>
+      <div class="field">
+        <%= f.label :state %>
+        <%= f.text_field :state, placeholder: "CO" %>
+      </div>
+      <div class="field">
+        <%= f.label :experience %>
+        <%= f.text_area :experience, rows: 3, placeholder: "This job was easy, but it didn't pay nearly enough and the customers were obnoxious." %>
+      </div>
+      <div class="field">
+        <%= f.label :pay %>
+        <%= f.text_area :pay, rows: 2, placeholder: "$15,000/year as a part time employee." %>
+      </div>
+      <div class="field">
+        <%= f.label :recommendation %>
+        <%= f.text_area :recommendation, rows: 2, placeholder: "It wouldn't be my first choice, but it's an easy, unskilled job if you really need cash." %>
+      </div>
+      <div class="field">
+        <%= f.label :website %>
+        <%= f.text_field :website, placeholder: "https://careers.walmart.com/" %>
+      </div>
+      <%= f.submit "Update", class: "ui button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/job_experiences/new.html.erb
+++ b/app/views/job_experiences/new.html.erb
@@ -34,6 +34,7 @@
         <%= f.label :website %>
         <%= f.text_field :website, placeholder: "https://careers.walmart.com/" %>
       </div>
+      <%= f.hidden_field :creator_id, value: @current_user.id %>
       <%= f.submit "Submit", class: "ui button" %>
     <% end %>
   </div>

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -34,7 +34,7 @@
           Location: <%= je.city %>, <%= je.state %>
         </div>
         <div class="ui label">
-          Where to apply: <a class="experience-link" href="<%= je.website %>"><%= je.website %></a>
+          Apply at <a class="experience-link" href="<%= je.website %>"><%= je.website %></a>
         </div>
         <div class="ui label">
           Created by <%= je.creator.first_name %> <%= je.creator.last_name %>

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -14,7 +14,7 @@
       <div class="ui header">
         <%= je.position %> at <%= je.company %>
         <% if @current_user %>
-          <div class="ui right floated button"><%= link_to "Update", edit_job_experience_path(je) %></div>
+          <div class="ui right floated button"><%= link_to "Edit", edit_job_experience_path(je) %></div>
         <% end %>
       </div>
       <div class="ui list">

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -13,6 +13,7 @@
     <div class="ui segment">
       <div class="ui header">
         <%= je.position %> at <%= je.company %>
+        <div class="ui right floated button"><%= link_to "Update", edit_job_experience_path(je) %></div>
       </div>
       <div class="ui list">
         <div class="item">

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -13,7 +13,9 @@
     <div class="ui segment">
       <div class="ui header">
         <%= je.position %> at <%= je.company %>
-        <div class="ui right floated button"><%= link_to "Update", edit_job_experience_path(je) %></div>
+        <% if @current_user %>
+          <div class="ui right floated button"><%= link_to "Update", edit_job_experience_path(je) %></div>
+        <% end %>
       </div>
       <div class="ui list">
         <div class="item">

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -39,6 +39,12 @@
         <div class="ui label">
           Created by <%= je.creator.first_name %> <%= je.creator.last_name %>
         </div>
+        <div class="ui label">
+          Collaborators:
+            <% je.collaborators.each do |collaborator| %>
+              <%= collaborator.user.first_name %> <%= collaborator.user.last_name %>
+            <% end %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/landings/index.html.erb
+++ b/app/views/landings/index.html.erb
@@ -14,9 +14,6 @@
       <div class="ui header">
         <%= je.position %> at <%= je.company %>
       </div>
-      <div class="ui label">
-        Location: <%= je.city %>, <%= je.state %>
-      </div>
       <div class="ui list">
         <div class="item">
           <div class="header">Experience</div>
@@ -30,9 +27,14 @@
           <div class="header">Recommendation</div>
           <%= je.recommendation %>
         </div>
-        <br>
         <div class="ui label">
-          Website: <a class="experience-link" href="<%= je.website %>"><%= je.website %></a>
+          Location: <%= je.city %>, <%= je.state %>
+        </div>
+        <div class="ui label">
+          Where to apply: <a class="experience-link" href="<%= je.website %>"><%= je.website %></a>
+        </div>
+        <div class="ui label">
+          Created by <%= je.creator.first_name %> <%= je.creator.last_name %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # authenticate token
   get "/auth/:id", to: "sessions#auth"
 
-  resources :job_experiences, only: [:new, :create]
+  resources :job_experiences, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20190101220420_add_creator_to_job_experience.rb
+++ b/db/migrate/20190101220420_add_creator_to_job_experience.rb
@@ -1,0 +1,6 @@
+class AddCreatorToJobExperience < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :job_experiences, :creator, index: true
+    add_foreign_key :job_experiences, :users, column: :creator_id
+  end
+end

--- a/db/migrate/20190101220420_add_user_job_experience_association.rb
+++ b/db/migrate/20190101220420_add_user_job_experience_association.rb
@@ -1,0 +1,8 @@
+class AddUserJobExperienceAssociation < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :users, :job_experiences, index: true
+    add_reference :job_experiences, :creator, index: true
+    add_foreign_key :job_experiences, :users, column: :creator_id
+    add_reference :job_experiences, :users, index: true
+  end
+end

--- a/db/migrate/20190101220420_add_user_job_experience_association.rb
+++ b/db/migrate/20190101220420_add_user_job_experience_association.rb
@@ -1,8 +1,0 @@
-class AddUserJobExperienceAssociation < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :users, :job_experiences, index: true
-    add_reference :job_experiences, :creator, index: true
-    add_foreign_key :job_experiences, :users, column: :creator_id
-    add_reference :job_experiences, :users, index: true
-  end
-end

--- a/db/migrate/20190103004410_create_collaborators.rb
+++ b/db/migrate/20190103004410_create_collaborators.rb
@@ -1,0 +1,9 @@
+class CreateCollaborators < ActiveRecord::Migration[5.2]
+  def change
+    create_table :collaborators do |t|
+      t.belongs_to :user, index: true
+      t.belongs_to :job_experience, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_16_225421) do
+ActiveRecord::Schema.define(version: 2019_01_01_220420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,10 @@ ActiveRecord::Schema.define(version: 2018_12_16_225421) do
     t.string "website"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "creator_id"
+    t.bigint "users_id"
+    t.index ["creator_id"], name: "index_job_experiences_on_creator_id"
+    t.index ["users_id"], name: "index_job_experiences_on_users_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,7 +40,10 @@ ActiveRecord::Schema.define(version: 2018_12_16_225421) do
     t.datetime "updated_at", null: false
     t.string "auth_token"
     t.datetime "auth_token_created_at"
+    t.bigint "job_experiences_id"
     t.index ["email"], name: "index_users_on_email"
+    t.index ["job_experiences_id"], name: "index_users_on_job_experiences_id"
   end
 
+  add_foreign_key "job_experiences", "users", column: "creator_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_01_220420) do
+ActiveRecord::Schema.define(version: 2019_01_03_004410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "collaborators", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "job_experience_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_experience_id"], name: "index_collaborators_on_job_experience_id"
+    t.index ["user_id"], name: "index_collaborators_on_user_id"
+  end
 
   create_table "job_experiences", force: :cascade do |t|
     t.string "position"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,9 +27,7 @@ ActiveRecord::Schema.define(version: 2019_01_01_220420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "creator_id"
-    t.bigint "users_id"
     t.index ["creator_id"], name: "index_job_experiences_on_creator_id"
-    t.index ["users_id"], name: "index_job_experiences_on_users_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,9 +38,7 @@ ActiveRecord::Schema.define(version: 2019_01_01_220420) do
     t.datetime "updated_at", null: false
     t.string "auth_token"
     t.datetime "auth_token_created_at"
-    t.bigint "job_experiences_id"
     t.index ["email"], name: "index_users_on_email"
-    t.index ["job_experiences_id"], name: "index_users_on_job_experiences_id"
   end
 
   add_foreign_key "job_experiences", "users", column: "creator_id"

--- a/spec/factories/job_experience.rb
+++ b/spec/factories/job_experience.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :job_experience, class: JobExperience do
-    position { "Cashier" }
-    company { "Target" }
-    city { "Fort Collins" }
-    state { "CO" }
+    position { Faker::Job.title }
+    company { Faker::Company.name }
+    city { Faker::Address.city }
+    state { Faker::Address.state_abbr }
     experience { "This job was horrible." }
-    pay { "$15k/year optimistically." }
+    pay { "$15k/year or so." }
     recommendation { "Don't take this job." }
-    website { "www.target.com" }
+    website { Faker::Internet.url }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user, class: User do
-    first_name { "Rusty" }
-    last_name { "Shackleford" }
-    email { "rusty@rustysshackles.com" }
+    first_name { Faker::Zelda.character }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
   end
 end

--- a/spec/features/edit_job_experience_spec.rb
+++ b/spec/features/edit_job_experience_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "edit job experience" do
+  let(:user) { create :user }
+  let!(:job_experience) { create :job_experience, creator_id: user.id }
+
+  scenario "a user updates a job experience they own" do
+    page.set_rack_session email: user.email
+    visit root_path
+    expect(page).to have_content(job_experience.company)
+
+    click_on "Update"
+    expect(page).to have_content "Update Your Job Experience"
+
+    fill_in "Position", with: "Cashier"
+    fill_in "Company", with: "Super Target"
+    fill_in "City", with: "Fort Collins"
+    fill_in "State", with: "CO"
+    fill_in "Experience", with: "Cashiering is pretty exhausting. Customers love to complain to cashiers, so you'll be hearing a lot of that. Plus, it doesn't pay much."
+    fill_in "Pay", with: "I worked at Super Target in 2010, so the pay went from $8/hour to $8.10/hour while I was there. It's probably slightly better now, but not by much."
+    fill_in "Recommendation", with: "Unless you desperately need a job, I would not recommend working at Super Target."
+    fill_in "Website", with: "www.target.com"
+    click_on "Update"
+    expect(page).to have_content("Your experience has been updated.")
+    expect(page).to have_content("Super Target")
+  end
+end

--- a/spec/features/edit_job_experience_spec.rb
+++ b/spec/features/edit_job_experience_spec.rb
@@ -20,6 +20,7 @@ feature "edit job experience" do
     expect(page).to have_content("This experience has been updated.")
     expect(page).to have_content("Super Target")
     expect(job_experience.reload.creator).to eq(user)
+    expect(page).to have_content("Collaborators: #{user.first_name} #{user.last_name}")
   end
 
   scenario "a user updates a job experience they don't own" do
@@ -33,6 +34,7 @@ feature "edit job experience" do
     expect(page).to have_content("This experience has been updated.")
     expect(page).to have_content("Cashiering at Target now pays $12/hour.")
     expect(job_experience.reload.creator).to eq(user)
+    expect(page).to have_content("Collaborators: #{the_other_guy.first_name} #{the_other_guy.last_name}")
   end
 
   scenario "a user is not signed in and tries to update a job experience" do

--- a/spec/features/edit_job_experience_spec.rb
+++ b/spec/features/edit_job_experience_spec.rb
@@ -9,8 +9,8 @@ feature "edit job experience" do
     sign_in user
     visit root_path
     expect(page).to have_content(job_experience.company)
-    click_on "Update"
-    expect(page).to have_content "Update Your Job Experience"
+    click_on "Edit"
+    expect(page).to have_content "Edit This Job Experience"
 
     fill_in "Position", with: "Cashier"
     fill_in "Company", with: "Super Target"
@@ -25,8 +25,8 @@ feature "edit job experience" do
   scenario "a user updates a job experience they don't own" do
     sign_in the_other_guy
     visit root_path
-    click_on "Update"
-    expect(page).to have_content "Update Your Job Experience"
+    click_on "Edit"
+    expect(page).to have_content "Edit This Job Experience"
 
     fill_in "Pay", with: "Cashiering at Target now pays $12/hour."
     click_on "Update"
@@ -37,7 +37,7 @@ feature "edit job experience" do
 
   scenario "a user is not signed in and tries to update a job experience" do
     visit root_path
-    expect(page).to_not have_content "Update"
+    expect(page).to_not have_content "Edit"
     visit edit_job_experience_path job_experience
     expect(page).to have_content "You are not authorized to perform this action."
   end

--- a/spec/features/edit_job_experience_spec.rb
+++ b/spec/features/edit_job_experience_spec.rb
@@ -2,26 +2,43 @@ require "rails_helper"
 
 feature "edit job experience" do
   let(:user) { create :user }
+  let(:the_other_guy) { create :user }
   let!(:job_experience) { create :job_experience, creator_id: user.id }
 
   scenario "a user updates a job experience they own" do
-    page.set_rack_session email: user.email
+    sign_in user
     visit root_path
     expect(page).to have_content(job_experience.company)
-
     click_on "Update"
     expect(page).to have_content "Update Your Job Experience"
 
     fill_in "Position", with: "Cashier"
     fill_in "Company", with: "Super Target"
-    fill_in "City", with: "Fort Collins"
-    fill_in "State", with: "CO"
     fill_in "Experience", with: "Cashiering is pretty exhausting. Customers love to complain to cashiers, so you'll be hearing a lot of that. Plus, it doesn't pay much."
     fill_in "Pay", with: "I worked at Super Target in 2010, so the pay went from $8/hour to $8.10/hour while I was there. It's probably slightly better now, but not by much."
-    fill_in "Recommendation", with: "Unless you desperately need a job, I would not recommend working at Super Target."
-    fill_in "Website", with: "www.target.com"
     click_on "Update"
-    expect(page).to have_content("Your experience has been updated.")
+    expect(page).to have_content("This experience has been updated.")
     expect(page).to have_content("Super Target")
+    expect(job_experience.reload.creator).to eq(user)
+  end
+
+  scenario "a user updates a job experience they don't own" do
+    sign_in the_other_guy
+    visit root_path
+    click_on "Update"
+    expect(page).to have_content "Update Your Job Experience"
+
+    fill_in "Pay", with: "Cashiering at Target now pays $12/hour."
+    click_on "Update"
+    expect(page).to have_content("This experience has been updated.")
+    expect(page).to have_content("Cashiering at Target now pays $12/hour.")
+    expect(job_experience.reload.creator).to eq(user)
+  end
+
+  scenario "a user is not signed in and tries to update a job experience" do
+    visit root_path
+    expect(page).to_not have_content "Update"
+    visit edit_job_experience_path job_experience
+    expect(page).to have_content "You are not authorized to perform this action."
   end
 end

--- a/spec/features/landing_spec.rb
+++ b/spec/features/landing_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 feature "landing" do
-  let!(:job_experience) { create :job_experience }
   let(:user) { create :user }
+  let!(:job_experience) { create :job_experience, creator_id: user.id }
 
   scenario "a user is not logged in" do
     visit root_path

--- a/spec/features/landing_spec.rb
+++ b/spec/features/landing_spec.rb
@@ -10,7 +10,7 @@ feature "landing" do
   end
 
   scenario "a user is logged in" do
-    page.set_rack_session email: user.email
+    sign_in user
     visit root_path
     expect(page).to have_content "Sign Out"
   end

--- a/spec/features/new_job_experience_spec.rb
+++ b/spec/features/new_job_experience_spec.rb
@@ -21,6 +21,8 @@ feature "new job experience" do
     click_on "Submit"
     expect(page).to have_content("Your experience has been saved.")
     expect(page).to have_content("T-Mobile")
+    expect(page).to have_content("Created by #{user.first_name} #{user.last_name}")
+    expect(page).to have_content("Collaborators: #{user.first_name} #{user.last_name}")
   end
 
   scenario "a user is not signed in and tries to create a job experience" do

--- a/spec/features/new_job_experience_spec.rb
+++ b/spec/features/new_job_experience_spec.rb
@@ -19,7 +19,7 @@ feature "new job experience" do
     fill_in "Recommendation", with: "It's a great place to work if you need a job or to pay the bills through college, but I wouldn't build a long-term career in T-Mobile retail."
     fill_in "Website", with: "www.t-mobile.com"
     click_on "Submit"
-    expect(page).to have_content("Your experience has been saved")
+    expect(page).to have_content("Your experience has been saved.")
     expect(page).to have_content("T-Mobile")
   end
 

--- a/spec/features/new_job_experience_spec.rb
+++ b/spec/features/new_job_experience_spec.rb
@@ -4,7 +4,7 @@ feature "new job experience" do
   let(:user) { create :user }
 
   scenario "a signed-in user creates a job experience" do
-    page.set_rack_session email: user.email
+    sign_in user
     visit root_path
 
     click_on "Share"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,8 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/poltergeist'
 require 'database_cleaner'
-require "rack_session_access/capybara"
+require 'rack_session_access/capybara'
+require 'faker'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -23,10 +24,8 @@ require "rack_session_access/capybara"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove these lines.
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e
@@ -71,6 +70,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
+  config.include SessionHelpers
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/session_helpers.rb
+++ b/spec/support/session_helpers.rb
@@ -1,0 +1,5 @@
+module SessionHelpers
+  def sign_in user
+    page.set_rack_session email: user.email
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

It allows users to edit and update JobExperiences as long as they are signed in. It also specifies the creator of the JobExperience so, later, they are the only ones who can delete it or manage it in other ways.

#### Background

Also added a `sign_in` helper for tests, Faker for factories, and better policies for JobExperiences in general.

#### Pivotal Tracker Item
Tracker [#162366202](https://www.pivotaltracker.com/story/show/162366202)

#### Screenshots

#### Affirm Completion
- [x] This PR has appropriate test coverage.
- [x] This PR has been tested for responsive design.
- [x] This PR requires a migration.